### PR TITLE
feat: Add cookie jar and api request to myself to avoid a login request with each API call

### DIFF
--- a/internal/provider/axwaystclient.go
+++ b/internal/provider/axwaystclient.go
@@ -39,7 +39,8 @@ func (c *AxwaySTClient) GenericAPIRequest(ctx context.Context, method, url strin
 		return
 	}
 	httpReq.Header.Add("Content-Type", "application/json")
-	httpReq.Header.Add("Authorization", c.auth)
+	httpReq.Header.Add("Referer", "terraform")
+	// httpReq.Header.Add("Authorization", c.auth)
 
 	httpResp, err := c.client.Do(httpReq)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces changes to the Axway provider implementation to enhance HTTP client configuration and modify request handling. The most significant updates include adding a cookie jar for token management, increasing the HTTP client timeout, and adjusting headers for API requests.

### HTTP Client Enhancements:
* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R7): Added a cookie jar to the HTTP client for token storage, enabling better session management. Increased the HTTP client timeout from 30 seconds to 120 seconds to accommodate longer API response times. [[1]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R7) [[2]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R125-R161)

### Request Handling Adjustments:
* [`internal/provider/axwaystclient.go`](diffhunk://#diff-7edc6a94c53c8f944118af2b8939cc0dda7bd5d19c3ef67f102f97c8217dcef0L42-R43): Replaced the `Authorization` header with a `Referer` header set to "terraform" in the `GenericAPIRequest` method.
* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R125-R161): Added logic to send an HTTP request to the `/api/v2.0/myself` endpoint during provider configuration for token generation and authentication.